### PR TITLE
Use controller as default image name

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: ghcr.io/onmetal/matryoshka:latest
+        image: controller
         name: manager
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
# Proposed Changes

In order to rewrite the image via kustomize we need to switch back to a dummy `controller` image name.