### PR TITLE
Add missing arg to auth proxy patch

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -24,3 +24,4 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - "--controllers=*"


### PR DESCRIPTION
# Proposed Changes

The auth proxy patch is removing the `--controllers=*` command line arg from the manager.