### PR TITLE
Making featureGates optional in CRD and regenerating manifests

### DIFF
--- a/apis/matryoshka/v1alpha1/kubeapiserver_types.go
+++ b/apis/matryoshka/v1alpha1/kubeapiserver_types.go
@@ -51,7 +51,7 @@ type KubeAPIServerSpec struct {
 	// ServiceAccount are service account settings for the api server.
 	ServiceAccount KubeAPIServerServiceAccount `json:"serviceAccount"`
 	// FeatureGates describe which alpha features should be enabled or beta features disabled
-	FeatureGates map[string]bool `json:"featureGates"`
+	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 }
 
 // KubeAPIServerPodTemplateOverlay is the template overlay for pods.

--- a/config/crd/bases/matryoshka.onmetal.de_kubeapiservers.yaml
+++ b/config/crd/bases/matryoshka.onmetal.de_kubeapiservers.yaml
@@ -175,7 +175,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -191,8 +191,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -371,7 +371,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -619,7 +619,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -831,7 +831,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1209,7 +1209,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1481,7 +1481,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -1497,8 +1497,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -1677,7 +1677,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -1925,7 +1925,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2137,7 +2137,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2515,7 +2515,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2787,123 +2787,128 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS
+                              description: 'awsElasticBlockStore represents an AWS
                                 Disk resource that is attached to a kubelet''s host
                                 machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty).'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the
-                                    ReadOnly property in VolumeMounts to "true". If
-                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource
-                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk
+                              description: azureDisk represents an Azure Data Disk
                                 mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only,
-                                    Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob
-                                    storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob
-                                    disks per storage account  Dedicated: single blob
-                                    disk per storage account  Managed: azure managed
-                                    data disk (only in managed availability set).
-                                    defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service
+                              description: azureFile represents an Azure File Service
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure
-                                    Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the
+                              description: cephFS represents a Ceph FS mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection
-                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root,
-                                    rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to
-                                    key ring for User, default is /etc/ceph/user.secret
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
                                     More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the authentication secret for User, default is
-                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -2913,31 +2918,32 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name,
-                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached
+                              description: 'cinder represents a cinder volume attached
                                 and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
+                                  description: 'readOnly defaults to false (read/write).
                                     ReadOnly here will force the ReadOnly setting
                                     in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object
-                                    containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -2947,32 +2953,32 @@ spec:
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume
+                                  description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should
+                              description: configMap represents a configMap that should
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
                                     will be projected into the volume as a file whose
                                     name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
@@ -2987,26 +2993,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -3019,28 +3027,28 @@ spec:
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents
+                              description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver
+                                  description: driver is the name of the CSI driver
                                     that handles this volume. Consult with your admin
                                     for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4",
-                                    "xfs", "ntfs". If not provided, the empty value
-                                    is passed to the associated CSI driver which will
-                                    determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference
+                                  description: nodePublishSecretRef is a reference
                                     to the secret object containing sensitive information
                                     to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
@@ -3057,13 +3065,13 @@ spec:
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration
+                                  description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific
+                                  description: volumeAttributes stores driver-specific
                                     properties that are passed to the CSI driver.
                                     Consult your driver's documentation for supported
                                     values.
@@ -3072,7 +3080,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about
+                              description: downwardAPI represents downward API about
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
@@ -3165,32 +3173,33 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory
+                              description: 'emptyDir represents a temporary directory
                                 that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is
+                              description: "ephemeral represents a volume that is
                                 handled by a cluster storage driver. The volume's
                                 lifecycle is tied to the pod that defines it - it
                                 will be created before the pod starts, and deleted
@@ -3267,15 +3276,15 @@ spec:
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired
+                                          description: 'accessModes contains the desired
                                             access modes the volume should have. More
                                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to
-                                            specify either: * An existing VolumeSnapshot
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
                                             If the provisioner or an external controller
@@ -3308,10 +3317,10 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from
-                                            which to populate the volume with data,
-                                            if a non-empty volume is desired. This
-                                            may be any local object from a non-empty
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
                                             API group (non core object) or a PersistentVolumeClaim
                                             object. When this field is specified,
                                             volume binding will only succeed if the
@@ -3333,7 +3342,7 @@ spec:
                                             objects. * While DataSource ignores disallowed
                                             values (dropping them), DataSourceRef   preserves
                                             all values, and generates an error if
-                                            a disallowed value is   specified. (Alpha)
+                                            a disallowed value is   specified. (Beta)
                                             Using this field requires the AnyVolumeDataSource
                                             feature gate to be enabled.'
                                           properties:
@@ -3358,7 +3367,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum
+                                          description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
                                             feature is enabled users are allowed to
                                             specify resource requirements that are
@@ -3395,8 +3404,8 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3450,8 +3459,9 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -3460,7 +3470,7 @@ spec:
                                             in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference
+                                          description: volumeName is the binding reference
                                             to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
@@ -3469,74 +3479,75 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource
+                              description: fc represents a Fibre Channel resource
                                 that is attached to a kubelet's host machine and then
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified. TODO: how
                                     do we prevent errors in the filesystem from compromising
                                     the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names
-                                    (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers
-                                    (wwids) Either wwids or combination of targetWWNs
-                                    and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume
+                              description: flexVolume represents a generic volume
                                 resource that is provisioned/attached using an exec
                                 based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to
+                                  description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". The default
-                                    filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if
-                                    any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the secret object containing sensitive information
-                                    to pass to the plugin scripts. This may be empty
-                                    if no secret object is specified. If the secret
-                                    object contains more than one secret, all secrets
-                                    are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -3549,28 +3560,28 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached
+                              description: flocker represents a Flocker volume attached
                                 to a kubelet's host machine. This depends on the Flocker
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata
-                                    -> name on the dataset for Flocker should be considered
-                                    as deprecated
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique
-                                    identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk
+                              description: 'gcePersistentDisk represents a GCE Disk
                                 resource that is attached to a kubelet''s host machine
                                 and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
                                     type is supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred
                                     to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -3578,21 +3589,22 @@ spec:
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in
-                                    GCE. Used to identify the disk in GCE. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
@@ -3600,7 +3612,7 @@ spec:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at
+                              description: 'gitRepo represents a git repository at
                                 a particular revision. DEPRECATED: GitRepo is deprecated.
                                 To provision a container with a git repo, mount an
                                 EmptyDir into an InitContainer that clones the repo
@@ -3608,37 +3620,38 @@ spec:
                                 container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain
-                                    or start with '..'.  If '.' is supplied, the volume
-                                    directory will be the git repository.  Otherwise,
-                                    if specified, the volume will contain the git
-                                    repository in the subdirectory with the given
-                                    name.
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount
+                              description: 'glusterfs represents a Glusterfs mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name
-                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path.
+                                  description: 'path is the Glusterfs volume path.
                                     More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs
+                                  description: 'readOnly here will force the Glusterfs
                                     volume to be mounted with read-only permissions.
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
@@ -3647,7 +3660,7 @@ spec:
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file
+                              description: 'hostPath represents a pre-existing file
                                 or directory on the host machine that is directly
                                 exposed to the container. This is generally used for
                                 system agents or other privileged things that are
@@ -3658,71 +3671,73 @@ spec:
                                 directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host.
+                                  description: 'path of the directory on the host.
                                     If the path is a symlink, it will follow the link
                                     to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults
+                                  description: 'type for HostPath Volume Defaults
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource
+                              description: 'iscsi represents an ISCSI Disk resource
                                 that is attached to a kubelet''s host machine and
                                 then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP
-                                    authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP
-                                    authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName
-                                    is specified with iscsiInterface simultaneously,
-                                    new iSCSI interface <target portal>:<volume name>
-                                    will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI
-                                    transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal
-                                    is either an IP or ip_addr:port if the port is
-                                    other than default (typically TCP ports 860 and
-                                    3260).
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly
+                                  description: readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator
-                                    authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -3732,9 +3747,10 @@ spec:
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is
-                                    either an IP or ip_addr:port if the port is other
-                                    than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3742,24 +3758,24 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host
+                              description: 'nfs represents an NFS mount on the host
                                 that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server.
+                                  description: 'path that is exported by the NFS server.
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export
+                                  description: 'readOnly here will force the NFS export
                                     to be mounted with read-only permissions. Defaults
                                     to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address
+                                  description: 'server is the hostname or IP address
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
@@ -3767,132 +3783,133 @@ spec:
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents
+                              description: 'persistentVolumeClaimVolumeSource represents
                                 a reference to a PersistentVolumeClaim in the same
                                 namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  description: 'claimName is the name of a PersistentVolumeClaim
                                     in the same namespace as the pod using this volume.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController
+                              description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
                                 machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller
-                                    persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume
+                              description: portworxVolume represents a portworx volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type
+                                  description: fSType represents the filesystem type
                                     to mount Must be a filesystem type supported by
                                     the host operating system. Ex. "ext4", "xfs".
                                     Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx
+                                  description: volumeID uniquely identifies a Portworx
                                     volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets,
-                                configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on
-                                    created files by default. Must be an octal value
-                                    between 0000 and 0777 or a decimal value between
-                                    0 and 511. YAML accepts both octal and decimal
-                                    values, JSON requires decimal values for mode
-                                    bits. Directories within the path are not affected
-                                    by this setting. This might be in conflict with
-                                    other options that affect the file mode, like
-                                    fsGroup, and the result can be other mode bits
-                                    set.
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap
-                                          data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -3907,13 +3924,13 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI
-                                          data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume
@@ -4003,53 +4020,53 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret
-                                          data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -4064,16 +4081,16 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken
-                                          data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended
+                                            description: audience is the intended
                                               audience of the token. A recipient of
                                               a token must identify itself with an
                                               identifier specified in the audience
@@ -4082,7 +4099,7 @@ spec:
                                               the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the
+                                            description: expirationSeconds is the
                                               requested duration of validity of the
                                               service account token. As the token
                                               approaches expiration, the kubelet volume
@@ -4096,7 +4113,7 @@ spec:
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative
+                                            description: path is the path relative
                                               to the mount point of the file to project
                                               the token into.
                                             type: string
@@ -4107,36 +4124,36 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the
+                              description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default
+                                  description: group to map volume access to Default
                                     is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte
+                                  description: readOnly here will force the Quobyte
                                     volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple
+                                  description: registry represents a single or multiple
                                     Quobyte Registry services specified as a string
                                     as host:port pair (multiple entries are separated
                                     with commas) which acts as the central registry
                                     for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume
+                                  description: tenant owning the given Quobyte volume
                                     in the Backend Used with dynamically provisioned
                                     Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults
+                                  description: user to map volume access to Defaults
                                     to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references
+                                  description: volume is a string that references
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
@@ -4144,44 +4161,46 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount
+                              description: 'rbd represents a Rados Block Device mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for
+                                  description: 'keyring is the path to key ring for
                                     RBDUser. Default is /etc/ceph/keyring. More info:
                                     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication
+                                  description: 'secretRef is name of the authentication
                                     secret for RBDUser. If provided overrides keyring.
                                     Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
@@ -4193,37 +4212,38 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent
+                              description: scaleIO represents a ScaleIO persistent
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Default is
-                                    "xfs".
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API
-                                    Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection
-                                    Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret
+                                  description: secretRef references to the secret
                                     for ScaleIO user and other sensitive information.
                                     If this is not provided, Login operation will
                                     fail.
@@ -4236,26 +4256,26 @@ spec:
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication
-                                    with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a
-                                    volume should be ThickProvisioned or ThinProvisioned.
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated
-                                    with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured
-                                    in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created
-                                    in the ScaleIO system that is associated with
-                                    this volume source.
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4263,27 +4283,27 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should
+                              description: 'secret represents a secret that should
                                 populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
                                     paths, and unlisted keys will not be present.
                                     If a key is specified which is not present in
@@ -4296,26 +4316,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -4323,30 +4345,31 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume
+                              description: storageOS represents a StorageOS volume
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use
+                                  description: secretRef specifies the secret to use
                                     for obtaining the StorageOS API credentials.  If
                                     not specified, default values will be attempted.
                                   properties:
@@ -4358,12 +4381,12 @@ spec:
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name
+                                  description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
                                     unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope
+                                  description: volumeNamespace specifies the scope
                                     of the volume within StorageOS.  If no namespace
                                     is specified then the Pod's namespace will be
                                     used.  This allows the Kubernetes name scoping
@@ -4375,26 +4398,27 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume
+                              description: vsphereVolume represents a vSphere volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume
-                                    vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4713,9 +4737,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -4775,7 +4796,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4884,9 +4905,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -4943,7 +4962,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -5054,9 +5073,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -5116,7 +5132,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -5225,9 +5241,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -5284,7 +5298,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -6205,17 +6219,48 @@ spec:
                                 pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                 it is the maximum permitted difference between the
                                 number of matching pods in the target topology and
-                                the global minimum. For example, in a 3-zone cluster,
-                                MaxSkew is set to 1, and pods with the same labelSelector
-                                spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                - if MaxSkew is 1, incoming pod can only be scheduled
-                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                would make the ActualSkew(2-0) on zone1(zone2) violate
-                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
-                                scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                 it is used to give higher precedence to topologies
                                 that satisfy it. It''s a required field. Default value
                                 is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is an alpha field and requires enabling
+                                MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
@@ -6223,8 +6268,14 @@ spec:
                                 Nodes that have a label with this key and identical
                                 values are considered to be in the same topology.
                                 We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. It's
-                                a required field.
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes match the node selector. e.g. If TopologyKey
+                                is "kubernetes.io/hostname", each Node is a domain
+                                of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                                each zone is a domain of that topology. It's a required
+                                field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal
@@ -6368,7 +6419,6 @@ spec:
             required:
             - authentication
             - etcd
-            - featureGates
             - replicas
             - serviceAccount
             - version

--- a/config/crd/bases/matryoshka.onmetal.de_kubecontrollermanagers.yaml
+++ b/config/crd/bases/matryoshka.onmetal.de_kubecontrollermanagers.yaml
@@ -186,7 +186,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -202,8 +202,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -382,7 +382,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -630,7 +630,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -842,7 +842,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1220,7 +1220,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -1492,7 +1492,7 @@ spec:
                             to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker
+                              description: 'Arguments to the entrypoint. The container
                                 image''s CMD is used if this is not provided. Variable
                                 references $(VAR_NAME) are expanded using the container''s
                                 environment. If a variable cannot be resolved, the
@@ -1508,8 +1508,8 @@ spec:
                               type: array
                             command:
                               description: 'Entrypoint array. Not executed within
-                                a shell. The docker image''s ENTRYPOINT is used if
-                                this is not provided. Variable references $(VAR_NAME)
+                                a shell. The container image''s ENTRYPOINT is used
+                                if this is not provided. Variable references $(VAR_NAME)
                                 are expanded using the container''s environment. If
                                 a variable cannot be resolved, the reference in the
                                 input string will be unchanged. Double $$ are reduced
@@ -1688,7 +1688,7 @@ spec:
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images
+                              description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
                                 This field is optional to allow higher level config
                                 management to default or override container images
                                 in workload controllers like Deployments and StatefulSets.'
@@ -1936,7 +1936,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2148,7 +2148,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2526,7 +2526,7 @@ spec:
                                   type: integer
                                 grpc:
                                   description: GRPC specifies an action involving
-                                    a GRPC port. This is an alpha field and requires
+                                    a GRPC port. This is a beta field and requires
                                     enabling GRPCContainerProbe feature gate.
                                   properties:
                                     port:
@@ -2798,123 +2798,128 @@ spec:
                             may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS
+                              description: 'awsElasticBlockStore represents an AWS
                                 Disk resource that is attached to a kubelet''s host
                                 machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty).'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the
-                                    ReadOnly property in VolumeMounts to "true". If
-                                    omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource
-                                    in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk
+                              description: azureDisk represents an Azure Data Disk
                                 mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only,
-                                    Read Write.'
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob
-                                    storage
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob
-                                    disks per storage account  Dedicated: single blob
-                                    disk per storage account  Managed: azure managed
-                                    data disk (only in managed availability set).
-                                    defaults to shared'
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service
+                              description: azureFile represents an Azure File Service
                                 mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure
-                                    Storage Account Name and Key
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
+                                  description: shareName is the azure share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the
+                              description: cephFS represents a Ceph FS mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection
-                                    of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root,
-                                    rather than the full Ceph tree, default is /'
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to
-                                    key ring for User, default is /etc/ceph/user.secret
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
                                     More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the authentication secret for User, default is
-                                    empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -2924,31 +2929,32 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name,
-                                    default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached
+                              description: 'cinder represents a cinder volume attached
                                 and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
-                                    inferred to be "ext4" if unspecified. More info:
-                                    https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
+                                  description: 'readOnly defaults to false (read/write).
                                     ReadOnly here will force the ReadOnly setting
                                     in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object
-                                    containing parameters used to connect to OpenStack.'
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -2958,32 +2964,32 @@ spec:
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume
+                                  description: 'volumeID used to identify the volume
                                     in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should
+                              description: configMap represents a configMap that should
                                 populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced ConfigMap
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
                                     will be projected into the volume as a file whose
                                     name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
@@ -2998,26 +3004,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -3030,28 +3038,28 @@ spec:
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its
-                                    keys must be defined
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents
+                              description: csi (Container Storage Interface) represents
                                 ephemeral storage that is handled by certain external
                                 CSI drivers (Beta feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver
+                                  description: driver is the name of the CSI driver
                                     that handles this volume. Consult with your admin
                                     for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4",
-                                    "xfs", "ntfs". If not provided, the empty value
-                                    is passed to the associated CSI driver which will
-                                    determine the default filesystem to apply.
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference
+                                  description: nodePublishSecretRef is a reference
                                     to the secret object containing sensitive information
                                     to pass to the CSI driver to complete the CSI
                                     NodePublishVolume and NodeUnpublishVolume calls.
@@ -3068,13 +3076,13 @@ spec:
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration
+                                  description: readOnly specifies a read-only configuration
                                     for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific
+                                  description: volumeAttributes stores driver-specific
                                     properties that are passed to the CSI driver.
                                     Consult your driver's documentation for supported
                                     values.
@@ -3083,7 +3091,7 @@ spec:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about
+                              description: downwardAPI represents downward API about
                                 the pod that should populate this volume
                               properties:
                                 defaultMode:
@@ -3176,32 +3184,33 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory
+                              description: 'emptyDir represents a temporary directory
                                 that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should
-                                    back this directory. The default is "" which means
-                                    to use the node''s default medium. Must be an
-                                    empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required
-                                    for this EmptyDir volume. The size limit is also
-                                    applicable for memory medium. The maximum usage
-                                    on memory medium EmptyDir would be the minimum
-                                    value between the SizeLimit specified here and
-                                    the sum of memory limits of all containers in
-                                    a pod. The default is nil which means that the
-                                    limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             ephemeral:
-                              description: "Ephemeral represents a volume that is
+                              description: "ephemeral represents a volume that is
                                 handled by a cluster storage driver. The volume's
                                 lifecycle is tied to the pod that defines it - it
                                 will be created before the pod starts, and deleted
@@ -3278,15 +3287,15 @@ spec:
                                         are also valid here.
                                       properties:
                                         accessModes:
-                                          description: 'AccessModes contains the desired
+                                          description: 'accessModes contains the desired
                                             access modes the volume should have. More
                                             info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                           items:
                                             type: string
                                           type: array
                                         dataSource:
-                                          description: 'This field can be used to
-                                            specify either: * An existing VolumeSnapshot
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
                                             object (snapshot.storage.k8s.io/VolumeSnapshot)
                                             * An existing PVC (PersistentVolumeClaim)
                                             If the provisioner or an external controller
@@ -3319,10 +3328,10 @@ spec:
                                           - name
                                           type: object
                                         dataSourceRef:
-                                          description: 'Specifies the object from
-                                            which to populate the volume with data,
-                                            if a non-empty volume is desired. This
-                                            may be any local object from a non-empty
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
                                             API group (non core object) or a PersistentVolumeClaim
                                             object. When this field is specified,
                                             volume binding will only succeed if the
@@ -3344,7 +3353,7 @@ spec:
                                             objects. * While DataSource ignores disallowed
                                             values (dropping them), DataSourceRef   preserves
                                             all values, and generates an error if
-                                            a disallowed value is   specified. (Alpha)
+                                            a disallowed value is   specified. (Beta)
                                             Using this field requires the AnyVolumeDataSource
                                             feature gate to be enabled.'
                                           properties:
@@ -3369,7 +3378,7 @@ spec:
                                           - name
                                           type: object
                                         resources:
-                                          description: 'Resources represents the minimum
+                                          description: 'resources represents the minimum
                                             resources the volume should have. If RecoverVolumeExpansionFailure
                                             feature is enabled users are allowed to
                                             specify resource requirements that are
@@ -3406,8 +3415,8 @@ spec:
                                               type: object
                                           type: object
                                         selector:
-                                          description: A label query over volumes
-                                            to consider for binding.
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -3461,8 +3470,9 @@ spec:
                                               type: object
                                           type: object
                                         storageClassName:
-                                          description: 'Name of the StorageClass required
-                                            by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                           type: string
                                         volumeMode:
                                           description: volumeMode defines what type
@@ -3471,7 +3481,7 @@ spec:
                                             in claim spec.
                                           type: string
                                         volumeName:
-                                          description: VolumeName is the binding reference
+                                          description: volumeName is the binding reference
                                             to the PersistentVolume backing this claim.
                                           type: string
                                       type: object
@@ -3480,74 +3490,75 @@ spec:
                                   type: object
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource
+                              description: fc represents a Fibre Channel resource
                                 that is attached to a kubelet's host machine and then
                                 exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be
-                                    a filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified. TODO: how
                                     do we prevent errors in the filesystem from compromising
                                     the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
+                                  description: 'lun is Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names
-                                    (WWNs)'
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers
-                                    (wwids) Either wwids or combination of targetWWNs
-                                    and lun must be set, but not both simultaneously.'
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume
+                              description: flexVolume represents a generic volume
                                 resource that is provisioned/attached using an exec
                                 based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to
+                                  description: driver is the name of the driver to
                                     use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". The default
-                                    filesystem depends on FlexVolume script.
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if
-                                    any.'
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write).
-                                    ReadOnly here will force the ReadOnly setting
-                                    in VolumeMounts.'
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to
-                                    the secret object containing sensitive information
-                                    to pass to the plugin scripts. This may be empty
-                                    if no secret object is specified. If the secret
-                                    object contains more than one secret, all secrets
-                                    are passed to the plugin scripts.'
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -3560,28 +3571,28 @@ spec:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached
+                              description: flocker represents a Flocker volume attached
                                 to a kubelet's host machine. This depends on the Flocker
                                 control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata
-                                    -> name on the dataset for Flocker should be considered
-                                    as deprecated
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique
-                                    identifier of a Flocker dataset
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk
+                              description: 'gcePersistentDisk represents a GCE Disk
                                 resource that is attached to a kubelet''s host machine
                                 and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
                                     type is supported by the host operating system.
                                     Examples: "ext4", "xfs", "ntfs". Implicitly inferred
                                     to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
@@ -3589,21 +3600,22 @@ spec:
                                     from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you
-                                    want to mount. If omitted, the default is to mount
-                                    by volume name. Examples: For volume /dev/sda1,
-                                    you specify the partition as "1". Similarly, the
-                                    volume partition for /dev/sda is "0" (or you can
-                                    leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in
-                                    GCE. Used to identify the disk in GCE. More info:
-                                    https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
@@ -3611,7 +3623,7 @@ spec:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at
+                              description: 'gitRepo represents a git repository at
                                 a particular revision. DEPRECATED: GitRepo is deprecated.
                                 To provision a container with a git repo, mount an
                                 EmptyDir into an InitContainer that clones the repo
@@ -3619,37 +3631,38 @@ spec:
                                 container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain
-                                    or start with '..'.  If '.' is supplied, the volume
-                                    directory will be the git repository.  Otherwise,
-                                    if specified, the volume will contain the git
-                                    repository in the subdirectory with the given
-                                    name.
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
+                                  description: repository is the URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
+                                  description: revision is the commit hash for the
+                                    specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount
+                              description: 'glusterfs represents a Glusterfs mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name
-                                    that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path.
+                                  description: 'path is the Glusterfs volume path.
                                     More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs
+                                  description: 'readOnly here will force the Glusterfs
                                     volume to be mounted with read-only permissions.
                                     Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
@@ -3658,7 +3671,7 @@ spec:
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file
+                              description: 'hostPath represents a pre-existing file
                                 or directory on the host machine that is directly
                                 exposed to the container. This is generally used for
                                 system agents or other privileged things that are
@@ -3669,71 +3682,73 @@ spec:
                                 directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host.
+                                  description: 'path of the directory on the host.
                                     If the path is a symlink, it will follow the link
                                     to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults
+                                  description: 'type for HostPath Volume Defaults
                                     to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource
+                              description: 'iscsi represents an ISCSI Disk resource
                                 that is attached to a kubelet''s host machine and
                                 then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP
-                                    authentication
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP
-                                    authentication
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName
-                                    is specified with iscsiInterface simultaneously,
-                                    new iSCSI interface <target portal>:<volume name>
-                                    will be created for the connection.
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
+                                  description: iqn is the target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI
-                                    transport. Defaults to 'default' (tcp).
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
+                                  description: lun represents iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal
-                                    is either an IP or ip_addr:port if the port is
-                                    other than default (typically TCP ports 860 and
-                                    3260).
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly
+                                  description: readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator
-                                    authentication
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
                                   properties:
                                     name:
                                       description: 'Name of the referent. More info:
@@ -3743,9 +3758,10 @@ spec:
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is
-                                    either an IP or ip_addr:port if the port is other
-                                    than default (typically TCP ports 860 and 3260).
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -3753,24 +3769,24 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host
+                              description: 'nfs represents an NFS mount on the host
                                 that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server.
+                                  description: 'path that is exported by the NFS server.
                                     More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export
+                                  description: 'readOnly here will force the NFS export
                                     to be mounted with read-only permissions. Defaults
                                     to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address
+                                  description: 'server is the hostname or IP address
                                     of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
@@ -3778,132 +3794,133 @@ spec:
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents
+                              description: 'persistentVolumeClaimVolumeSource represents
                                 a reference to a PersistentVolumeClaim in the same
                                 namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim
+                                  description: 'claimName is the name of a PersistentVolumeClaim
                                     in the same namespace as the pod using this volume.
                                     More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in
-                                    VolumeMounts. Default false.
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController
+                              description: photonPersistentDisk represents a PhotonController
                                 persistent disk attached and mounted on kubelets host
                                 machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller
-                                    persistent disk
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume
+                              description: portworxVolume represents a portworx volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type
+                                  description: fSType represents the filesystem type
                                     to mount Must be a filesystem type supported by
                                     the host operating system. Ex. "ext4", "xfs".
                                     Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx
+                                  description: volumeID uniquely identifies a Portworx
                                     volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets,
-                                configmaps, and downward API
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits used to set permissions on
-                                    created files by default. Must be an octal value
-                                    between 0000 and 0777 or a decimal value between
-                                    0 and 511. YAML accepts both octal and decimal
-                                    values, JSON requires decimal values for mode
-                                    bits. Directories within the path are not affected
-                                    by this setting. This might be in conflict with
-                                    other options that affect the file mode, like
-                                    fsGroup, and the result can be other mode bits
-                                    set.
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
+                                  description: sources is the list of volume projections
                                   items:
                                     description: Projection that may be projected
                                       along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap
-                                          data to project
+                                        description: configMap information about the
+                                          configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              ConfigMap will be projected into the
-                                              volume as a file whose name is the key
-                                              and content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the ConfigMap,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -3918,13 +3935,13 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap
-                                              or its keys must be defined
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI
-                                          data to project
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
                                         properties:
                                           items:
                                             description: Items is a list of DownwardAPIVolume
@@ -4014,53 +4031,53 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret
-                                          data to project
+                                        description: secret information about the
+                                          secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value
-                                              pair in the Data field of the referenced
-                                              Secret will be projected into the volume
-                                              as a file whose name is the key and
-                                              content is the value. If specified,
-                                              the listed keys will be projected into
-                                              the specified paths, and unlisted keys
-                                              will not be present. If a key is specified
-                                              which is not present in the Secret,
-                                              the volume setup will error unless it
-                                              is marked optional. Paths must be relative
-                                              and may not contain the '..' path or
-                                              start with '..'.
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
                                             items:
                                               description: Maps a string key to a
                                                 path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
+                                                  description: key is the key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits
-                                                    used to set permissions on this
-                                                    file. Must be an octal value between
-                                                    0000 and 0777 or a decimal value
-                                                    between 0 and 511. YAML accepts
-                                                    both octal and decimal values,
-                                                    JSON requires decimal values for
-                                                    mode bits. If not specified, the
-                                                    volume defaultMode will be used.
-                                                    This might be in conflict with
-                                                    other options that affect the
-                                                    file mode, like fsGroup, and the
-                                                    result can be other mode bits
-                                                    set.'
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of
-                                                    the file to map the key to. May
-                                                    not be an absolute path. May not
-                                                    contain the path element '..'.
-                                                    May not start with the string
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
                                                     '..'.
                                                   type: string
                                               required:
@@ -4075,16 +4092,16 @@ spec:
                                               kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret
-                                              or its key must be defined
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken
-                                          data to project
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended
+                                            description: audience is the intended
                                               audience of the token. A recipient of
                                               a token must identify itself with an
                                               identifier specified in the audience
@@ -4093,7 +4110,7 @@ spec:
                                               the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the
+                                            description: expirationSeconds is the
                                               requested duration of validity of the
                                               service account token. As the token
                                               approaches expiration, the kubelet volume
@@ -4107,7 +4124,7 @@ spec:
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative
+                                            description: path is the path relative
                                               to the mount point of the file to project
                                               the token into.
                                             type: string
@@ -4118,36 +4135,36 @@ spec:
                                   type: array
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the
+                              description: quobyte represents a Quobyte mount on the
                                 host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default
+                                  description: group to map volume access to Default
                                     is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte
+                                  description: readOnly here will force the Quobyte
                                     volume to be mounted with read-only permissions.
                                     Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple
+                                  description: registry represents a single or multiple
                                     Quobyte Registry services specified as a string
                                     as host:port pair (multiple entries are separated
                                     with commas) which acts as the central registry
                                     for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume
+                                  description: tenant owning the given Quobyte volume
                                     in the Backend Used with dynamically provisioned
                                     Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults
+                                  description: user to map volume access to Defaults
                                     to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references
+                                  description: volume is a string that references
                                     an already created Quobyte volume by name.
                                   type: string
                               required:
@@ -4155,44 +4172,46 @@ spec:
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount
+                              description: 'rbd represents a Rados Block Device mount
                                 on the host that shares a pod''s lifetime. More info:
                                 https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that
-                                    you want to mount. Tip: Ensure that the filesystem
-                                    type is supported by the host operating system.
-                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
-                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
                                     TODO: how do we prevent errors in the filesystem
                                     from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for
+                                  description: 'keyring is the path to key ring for
                                     RBDUser. Default is /etc/ceph/keyring. More info:
                                     https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More
-                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly
+                                  description: 'readOnly here will force the ReadOnly
                                     setting in VolumeMounts. Defaults to false. More
                                     info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication
+                                  description: 'secretRef is name of the authentication
                                     secret for RBDUser. If provided overrides keyring.
                                     Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
@@ -4204,37 +4223,38 @@ spec:
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin.
-                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent
+                              description: scaleIO represents a ScaleIO persistent
                                 volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Default is
-                                    "xfs".
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API
-                                    Gateway.
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection
-                                    Domain for the configured storage.
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret
+                                  description: secretRef references to the secret
                                     for ScaleIO user and other sensitive information.
                                     If this is not provided, Login operation will
                                     fail.
@@ -4247,26 +4267,26 @@ spec:
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication
-                                    with Gateway, default false
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a
-                                    volume should be ThickProvisioned or ThinProvisioned.
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
                                     Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated
-                                    with the protection domain.
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured
-                                    in ScaleIO.
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created
-                                    in the ScaleIO system that is associated with
-                                    this volume source.
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -4274,27 +4294,27 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should
+                              description: 'secret represents a secret that should
                                 populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair
-                                    in the Data field of the referenced Secret will
-                                    be projected into the volume as a file whose name
-                                    is the key and content is the value. If specified,
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
                                     the listed keys will be projected into the specified
                                     paths, and unlisted keys will not be present.
                                     If a key is specified which is not present in
@@ -4307,26 +4327,28 @@ spec:
                                       a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
+                                        description: key is the key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file
-                                          to map the key to. May not be an absolute
-                                          path. May not contain the path element '..'.
-                                          May not start with the string '..'.
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
                                         type: string
                                     required:
                                     - key
@@ -4334,30 +4356,31 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys
-                                    must be defined
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume
+                              description: storageOS represents a StorageOS volume
                                 attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly
-                                    here will force the ReadOnly setting in VolumeMounts.
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use
+                                  description: secretRef specifies the secret to use
                                     for obtaining the StorageOS API credentials.  If
                                     not specified, default values will be attempted.
                                   properties:
@@ -4369,12 +4392,12 @@ spec:
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name
+                                  description: volumeName is the human-readable name
                                     of the StorageOS volume.  Volume names are only
                                     unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope
+                                  description: volumeNamespace specifies the scope
                                     of the volume within StorageOS.  If no namespace
                                     is specified then the Pod's namespace will be
                                     used.  This allows the Kubernetes name scoping
@@ -4386,26 +4409,27 @@ spec:
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume
+                              description: vsphereVolume represents a vSphere volume
                                 attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a
-                                    filesystem type supported by the host operating
-                                    system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
                                     inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile ID associated with the StoragePolicyName.
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM)
-                                    profile name.
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume
-                                    vmdk
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -4724,9 +4748,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -4786,7 +4807,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -4895,9 +4916,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -4954,7 +4973,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -5065,9 +5084,6 @@ spec:
                                             null selector and null or empty namespaces
                                             list means "this pod's namespace". An
                                             empty selector ({}) matches all namespaces.
-                                            This field is beta-level and is only honored
-                                            when PodAffinityNamespaceSelector feature
-                                            is enabled.
                                           properties:
                                             matchExpressions:
                                               description: matchExpressions is a list
@@ -5127,7 +5143,7 @@ spec:
                                             union of the namespaces listed in this
                                             field and the ones selected by namespaceSelector.
                                             null or empty namespaces list and null
-                                            namespaceSelector means "this pod's namespace"
+                                            namespaceSelector means "this pod's namespace".
                                           items:
                                             type: string
                                           type: array
@@ -5236,9 +5252,7 @@ spec:
                                         this field and the ones listed in the namespaces
                                         field. null selector and null or empty namespaces
                                         list means "this pod's namespace". An empty
-                                        selector ({}) matches all namespaces. This
-                                        field is beta-level and is only honored when
-                                        PodAffinityNamespaceSelector feature is enabled.
+                                        selector ({}) matches all namespaces.
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list
@@ -5295,7 +5309,7 @@ spec:
                                         listed in this field and the ones selected
                                         by namespaceSelector. null or empty namespaces
                                         list and null namespaceSelector means "this
-                                        pod's namespace"
+                                        pod's namespace".
                                       items:
                                         type: string
                                       type: array
@@ -6216,17 +6230,48 @@ spec:
                                 pods may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
                                 it is the maximum permitted difference between the
                                 number of matching pods in the target topology and
-                                the global minimum. For example, in a 3-zone cluster,
-                                MaxSkew is set to 1, and pods with the same labelSelector
-                                spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       |
-                                - if MaxSkew is 1, incoming pod can only be scheduled
-                                to zone3 to become 1/1/1; scheduling it onto zone1(zone2)
-                                would make the ActualSkew(2-0) on zone1(zone2) violate
-                                MaxSkew(1). - if MaxSkew is 2, incoming pod can be
-                                scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
+                                the global minimum. The global minimum is the minimum
+                                number of matching pods in an eligible domain or zero
+                                if the number of eligible domains is less than MinDomains.
+                                For example, in a 3-zone cluster, MaxSkew is set to
+                                1, and pods with the same labelSelector spread as
+                                2/2/1: In this case, the global minimum is 1. | zone1
+                                | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
+                                is 1, incoming pod can only be scheduled to zone3
+                                to become 2/2/2; scheduling it onto zone1(zone2) would
+                                make the ActualSkew(3-1) on zone1(zone2) violate MaxSkew(1).
+                                - if MaxSkew is 2, incoming pod can be scheduled onto
+                                any zone. When `whenUnsatisfiable=ScheduleAnyway`,
                                 it is used to give higher precedence to topologies
                                 that satisfy it. It''s a required field. Default value
                                 is 1 and 0 is not allowed.'
+                              format: int32
+                              type: integer
+                            minDomains:
+                              description: "MinDomains indicates a minimum number
+                                of eligible domains. When the number of eligible domains
+                                with matching topology keys is less than minDomains,
+                                Pod Topology Spread treats \"global minimum\" as 0,
+                                and then the calculation of Skew is performed. And
+                                when the number of eligible domains with matching
+                                topology keys equals or greater than minDomains, this
+                                value has no effect on scheduling. As a result, when
+                                the number of eligible domains is less than minDomains,
+                                scheduler won't schedule more than maxSkew Pods to
+                                those domains. If value is nil, the constraint behaves
+                                as if MinDomains is equal to 1. Valid values are integers
+                                greater than 0. When value is not nil, WhenUnsatisfiable
+                                must be DoNotSchedule. \n For example, in a 3-zone
+                                cluster, MaxSkew is set to 2, MinDomains is set to
+                                5 and pods with the same labelSelector spread as 2/2/2:
+                                | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
+                                The number of domains is less than 5(MinDomains),
+                                so \"global minimum\" is treated as 0. In this situation,
+                                new pod with the same labelSelector cannot be scheduled,
+                                because computed skew will be 3(3 - 0) if new Pod
+                                is scheduled to any of the three zones, it will violate
+                                MaxSkew. \n This is an alpha field and requires enabling
+                                MinDomainsInPodTopologySpread feature gate."
                               format: int32
                               type: integer
                             topologyKey:
@@ -6234,8 +6279,14 @@ spec:
                                 Nodes that have a label with this key and identical
                                 values are considered to be in the same topology.
                                 We consider each <key, value> as a "bucket", and try
-                                to put balanced number of pods into each bucket. It's
-                                a required field.
+                                to put balanced number of pods into each bucket. We
+                                define a domain as a particular instance of a topology.
+                                Also, we define an eligible domain as a domain whose
+                                nodes match the node selector. e.g. If TopologyKey
+                                is "kubernetes.io/hostname", each Node is a domain
+                                of that topology. And, if TopologyKey is "topology.kubernetes.io/zone",
+                                each zone is a domain of that topology. It's a required
+                                field.
                               type: string
                             whenUnsatisfiable:
                               description: 'WhenUnsatisfiable indicates how to deal


### PR DESCRIPTION
# Proposed Changes
- featureGates should be an optional attribute, as it is not required to set any specific feature overwrites.
- Regeneration of manifests lead to various description updates