### PR TITLE
Switch to registry.k8s.io registry

### DIFF
--- a/config/crd/bases/matryoshka.onmetal.de_kubeapiservers.yaml
+++ b/config/crd/bases/matryoshka.onmetal.de_kubeapiservers.yaml
@@ -988,7 +988,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -2324,7 +2325,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -3486,7 +3488,8 @@ spec:
                                                 that are used by this container. \n
                                                 This is an alpha field and requires
                                                 enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable."
+                                                feature gate. \n This field is immutable.
+                                                It can only be set for containers."
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
@@ -5752,7 +5755,8 @@ spec:
                                   defined in spec.resourceClaims, that are used by
                                   this container. \n This is an alpha field and requires
                                   enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable."
+                                  \n This field is immutable. It can only be set for
+                                  containers."
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.

--- a/config/crd/bases/matryoshka.onmetal.de_kubecontrollermanagers.yaml
+++ b/config/crd/bases/matryoshka.onmetal.de_kubecontrollermanagers.yaml
@@ -987,7 +987,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -2323,7 +2324,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -3485,7 +3487,8 @@ spec:
                                                 that are used by this container. \n
                                                 This is an alpha field and requires
                                                 enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable."
+                                                feature gate. \n This field is immutable.
+                                                It can only be set for containers."
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
@@ -5755,7 +5758,8 @@ spec:
                                   defined in spec.resourceClaims, that are used by
                                   this container. \n This is an alpha field and requires
                                   enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable."
+                                  \n This field is immutable. It can only be set for
+                                  containers."
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.

--- a/config/crd/bases/matryoshka.onmetal.de_kubeschedulers.yaml
+++ b/config/crd/bases/matryoshka.onmetal.de_kubeschedulers.yaml
@@ -959,7 +959,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -2295,7 +2296,8 @@ spec:
                                     defined in spec.resourceClaims, that are used
                                     by this container. \n This is an alpha field and
                                     requires enabling the DynamicResourceAllocation
-                                    feature gate. \n This field is immutable."
+                                    feature gate. \n This field is immutable. It can
+                                    only be set for containers."
                                   items:
                                     description: ResourceClaim references one entry
                                       in PodSpec.ResourceClaims.
@@ -3457,7 +3459,8 @@ spec:
                                                 that are used by this container. \n
                                                 This is an alpha field and requires
                                                 enabling the DynamicResourceAllocation
-                                                feature gate. \n This field is immutable."
+                                                feature gate. \n This field is immutable.
+                                                It can only be set for containers."
                                               items:
                                                 description: ResourceClaim references
                                                   one entry in PodSpec.ResourceClaims.
@@ -5838,7 +5841,8 @@ spec:
                                   defined in spec.resourceClaims, that are used by
                                   this container. \n This is an alpha field and requires
                                   enabling the DynamicResourceAllocation feature gate.
-                                  \n This field is immutable."
+                                  \n This field is immutable. It can only be set for
+                                  containers."
                                 items:
                                   description: ResourceClaim references one entry
                                     in PodSpec.ResourceClaims.

--- a/controllers/matryoshka/internal/kubeapiserver/kubeapiserver.go
+++ b/controllers/matryoshka/internal/kubeapiserver/kubeapiserver.go
@@ -348,7 +348,7 @@ func (r *Resolver) probeForPath(ctx context.Context, s *memorystore.Store, serve
 func (r *Resolver) apiServerContainer(server *matryoshkav1alpha1.KubeAPIServer) (*corev1.Container, error) {
 	container := &corev1.Container{
 		Name:    "kube-apiserver",
-		Image:   fmt.Sprintf("k8s.gcr.io/kube-apiserver:v%s", server.Spec.Version),
+		Image:   fmt.Sprintf("registry.k8s.io/kube-apiserver:v%s", server.Spec.Version),
 		Command: r.apiServerCommand(server),
 		Ports: []corev1.ContainerPort{
 			{

--- a/controllers/matryoshka/internal/kubecontrollermanager/kubecontrollermanager.go
+++ b/controllers/matryoshka/internal/kubecontrollermanager/kubecontrollermanager.go
@@ -153,7 +153,7 @@ func (r *Resolver) updateDeploymentChecksums(ctx context.Context, s *memorystore
 func (r *Resolver) controllerManagerContainer(_ context.Context, _ *memorystore.Store, kcm *matryoshkav1alpha1.KubeControllerManager) (*corev1.Container, error) {
 	container := &corev1.Container{
 		Name:         "kube-controller-manager",
-		Image:        fmt.Sprintf("k8s.gcr.io/kube-controller-manager:v%s", kcm.Spec.Version),
+		Image:        fmt.Sprintf("registry.k8s.io/kube-controller-manager:v%s", kcm.Spec.Version),
 		Command:      r.kubeControllerManagerCommand(kcm),
 		VolumeMounts: r.kubeControllerManagerVolumeMounts(kcm),
 		LivenessProbe: &corev1.Probe{

--- a/controllers/matryoshka/internal/kubescheduler/kubescheduler.go
+++ b/controllers/matryoshka/internal/kubescheduler/kubescheduler.go
@@ -131,7 +131,7 @@ func (r *Resolver) updateDeploymentChecksums(ctx context.Context, s *memorystore
 func (r *Resolver) schedulerContainer(_ context.Context, _ *memorystore.Store, ks *matryoshkav1alpha1.KubeScheduler) (*corev1.Container, error) {
 	container := &corev1.Container{
 		Name:         "kube-scheduler",
-		Image:        fmt.Sprintf("k8s.gcr.io/kube-scheduler:v%s", ks.Spec.Version),
+		Image:        fmt.Sprintf("registry.k8s.io/kube-scheduler:v%s", ks.Spec.Version),
 		Command:      r.kubeSchedulerCommand(ks),
 		VolumeMounts: r.kubeSchedulerVolumeMounts(ks),
 		LivenessProbe: &corev1.Probe{


### PR DESCRIPTION
# Proposed Changes

As of March 20th 2023 all Kubernetes related images moved from `k8s.gcr.io` to `registry.k8s.io`. Please see the announcement for further details: https://kubernetes.io/blog/2023/03/10/image-registry-redirect/